### PR TITLE
fix(hnsw): use negative of the radius when the distance metric is dot product for HNSW range search

### DIFF
--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -373,6 +373,15 @@ void IndexHNSW::range_search(
         float radius,
         RangeSearchResult* result,
         const SearchParameters* params) const {
+    // Since we use NegativeDistanceComputer for similarity search and include a result if 
+    // distance < radius, the inequality is effectively changed from (distance > radius) 
+    // to (-radius > -distance).
+    //
+    if (is_similarity_metric(this->metric_type))
+    {
+        radius *= -1;
+    }
+
     using RH = RangeSearchBlockResultHandler<HNSW::C>;
     RH bres(result, radius);
 


### PR DESCRIPTION
The `range_search` method in `IndexHNSW` uses a 'negative distance computer' to compare dot product distances to maintain parity with L2 distance comparison. Essentially, the inequality 'distance > threshold' is changed to 'threshold > -distance' instead of the correct '-threshold > -distance'. So we multiply the radius (or threshold) by -1 to correct the inequality check.